### PR TITLE
Proxies don't need TLS to the server

### DIFF
--- a/draft-thomson-http-oblivious.md
+++ b/draft-thomson-http-oblivious.md
@@ -909,10 +909,9 @@ encapsulated response.
 A proxy MUST NOT add information about the client identity when forwarding
 requests. This includes the Via field, the Forwarded field
 {{?FORWARDED=RFC7239}}, and any similar information.  A client does not depend
-on the proxy using an authenticated connection to the oblivious request
+on the proxy using an authenticated and encrypted connection to the oblivious request
 resource, only that information about the client not be attached to forwarded
-requests.  A proxy SHOULD use TLS to protect requests that it forwards, as that
-can make some traffic analysis countermeasures taken by clients more effective.
+requests. 
 
 
 ### Denial of Service {#dos}

--- a/draft-thomson-http-oblivious.md
+++ b/draft-thomson-http-oblivious.md
@@ -908,7 +908,11 @@ encapsulated response.
 
 A proxy MUST NOT add information about the client identity when forwarding
 requests. This includes the Via field, the Forwarded field
-{{?FORWARDED=RFC7239}}, and any similar information.
+{{?FORWARDED=RFC7239}}, and any similar information.  A client does not depend
+on the proxy using an authenticated connection to the oblivious request
+resource, only that information about the client not be attached to forwarded
+requests.  A proxy SHOULD use TLS to protect requests that it forwards, as that
+can make some traffic analysis countermeasures taken by clients more effective.
 
 
 ### Denial of Service {#dos}


### PR DESCRIPTION
But they should.  Consider the case where clients have equal-sized
messages, but are making requests using different key identifiers or
different request targets.  If that information could be linked to
certain clients, encryption would increase the size of the anonymity set
from the perspective of a passive observer for little extra cost.

Closes #56.